### PR TITLE
Add necessary fields for appchain registration.

### DIFF
--- a/appchain-registry/src/appchain_basedata.rs
+++ b/appchain-registry/src/appchain_basedata.rs
@@ -30,13 +30,24 @@ impl AppchainMetadata {
     pub fn from_old_version(old_version: &OldAppchainMetadata) -> Self {
         Self {
             website_url: old_version.website_url.clone(),
+            function_spec_url: String::new(),
             github_address: old_version.github_address.clone(),
             github_release: old_version.github_release.clone(),
             commit_id: old_version.commit_id.clone(),
             contact_email: old_version.contact_email.clone(),
-            premined_wrapped_appchain_token: old_version.preminted_wrapped_appchain_token,
+            premined_wrapped_appchain_token_beneficiary: String::new(),
+            premined_wrapped_appchain_token: old_version.premined_wrapped_appchain_token,
             ido_amount_of_wrapped_appchain_token: old_version.ido_amount_of_wrapped_appchain_token,
             initial_era_reward: old_version.initial_era_reward,
+            fungible_token_metadata: FungibleTokenMetadata {
+                spec: String::new(),
+                name: String::new(),
+                symbol: String::new(),
+                icon: None,
+                reference: None,
+                reference_hash: None,
+                decimals: 0,
+            },
             custom_metadata: old_version.custom_metadata.clone(),
         }
     }

--- a/appchain-registry/src/lib.rs
+++ b/appchain-registry/src/lib.rs
@@ -11,6 +11,7 @@ mod upgradable;
 mod voter_actions;
 use std::collections::HashMap;
 
+use near_contract_standards::fungible_token::metadata::FungibleTokenMetadata;
 use near_contract_standards::upgrade::Ownable;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::{LazyOption, LookupMap, UnorderedSet};
@@ -116,13 +117,16 @@ enum RegistryDepositMessage {
     RegisterAppchain {
         appchain_id: String,
         website_url: String,
+        function_spec_url: String,
         github_address: String,
         github_release: String,
         commit_id: String,
         contact_email: String,
+        premined_wrapped_appchain_token_beneficiary: AccountId,
         premined_wrapped_appchain_token: U128,
         ido_amount_of_wrapped_appchain_token: U128,
         initial_era_reward: U128,
+        fungible_token_metadata: FungibleTokenMetadata,
         custom_metadata: HashMap<String, String>,
     },
     UpvoteAppchain {
@@ -233,13 +237,16 @@ impl AppchainRegistry {
             RegistryDepositMessage::RegisterAppchain {
                 appchain_id,
                 website_url,
+                function_spec_url,
                 github_address,
                 github_release,
                 commit_id,
                 contact_email,
+                premined_wrapped_appchain_token_beneficiary,
                 premined_wrapped_appchain_token,
                 ido_amount_of_wrapped_appchain_token,
                 initial_era_reward,
+                fungible_token_metadata,
                 custom_metadata,
             } => {
                 self.register_appchain(
@@ -247,13 +254,16 @@ impl AppchainRegistry {
                     appchain_id,
                     amount.0,
                     website_url,
+                    function_spec_url,
                     github_address,
                     github_release,
                     commit_id,
                     contact_email,
+                    premined_wrapped_appchain_token_beneficiary,
                     premined_wrapped_appchain_token,
                     ido_amount_of_wrapped_appchain_token,
                     initial_era_reward,
+                    fungible_token_metadata,
                     custom_metadata,
                 );
                 PromiseOrValue::Value(0.into())
@@ -303,13 +313,16 @@ impl AppchainRegistry {
         appchain_id: AppchainId,
         register_deposit: Balance,
         website_url: String,
+        function_spec_url: String,
         github_address: String,
         github_release: String,
         commit_id: String,
         contact_email: String,
+        premined_wrapped_appchain_token_beneficiary: AccountId,
         premined_wrapped_appchain_token: U128,
         ido_amount_of_wrapped_appchain_token: U128,
         initial_era_reward: U128,
+        fungible_token_metadata: FungibleTokenMetadata,
         custom_metadata: HashMap<String, String>,
     ) {
         assert!(
@@ -329,13 +342,16 @@ impl AppchainRegistry {
             appchain_id.clone(),
             AppchainMetadata {
                 website_url,
+                function_spec_url,
                 github_address,
                 github_release,
                 commit_id,
                 contact_email,
+                premined_wrapped_appchain_token_beneficiary,
                 premined_wrapped_appchain_token,
                 ido_amount_of_wrapped_appchain_token,
                 initial_era_reward,
+                fungible_token_metadata,
                 custom_metadata,
             },
             sender_id,

--- a/appchain-registry/src/registry_owner_actions.rs
+++ b/appchain-registry/src/registry_owner_actions.rs
@@ -9,13 +9,16 @@ pub trait RegistryOwnerActions {
         &mut self,
         appchain_id: AppchainId,
         website_url: Option<String>,
+        function_spec_url: Option<String>,
         github_address: Option<String>,
         github_release: Option<String>,
         commit_id: Option<String>,
         contact_email: Option<String>,
+        premined_wrapped_appchain_token_beneficiary: Option<AccountId>,
         premined_wrapped_appchain_token: Option<U128>,
         ido_amount_of_wrapped_appchain_token: Option<U128>,
         initial_era_reward: Option<U128>,
+        fungible_token_metadata: Option<FungibleTokenMetadata>,
         custom_metadata: Option<HashMap<String, String>>,
     );
     /// Start auditing of an appchain
@@ -38,13 +41,16 @@ impl RegistryOwnerActions for AppchainRegistry {
         &mut self,
         appchain_id: AppchainId,
         website_url: Option<String>,
+        function_spec_url: Option<String>,
         github_address: Option<String>,
         github_release: Option<String>,
         commit_id: Option<String>,
         contact_email: Option<String>,
+        premined_wrapped_appchain_token_beneficiary: Option<AccountId>,
         premined_wrapped_appchain_token: Option<U128>,
         ido_amount_of_wrapped_appchain_token: Option<U128>,
         initial_era_reward: Option<U128>,
+        fungible_token_metadata: Option<FungibleTokenMetadata>,
         custom_metadata: Option<HashMap<String, String>>,
     ) {
         self.assert_owner();
@@ -53,6 +59,10 @@ impl RegistryOwnerActions for AppchainRegistry {
         if let Some(website_url) = website_url {
             metadata.website_url.clear();
             metadata.website_url.push_str(&website_url);
+        }
+        if let Some(function_spec_url) = function_spec_url {
+            metadata.function_spec_url.clear();
+            metadata.function_spec_url.push_str(&function_spec_url);
         }
         if let Some(github_address) = github_address {
             metadata.github_address.clear();
@@ -70,6 +80,14 @@ impl RegistryOwnerActions for AppchainRegistry {
             metadata.contact_email.clear();
             metadata.contact_email.push_str(&contact_email);
         }
+        if let Some(premined_wrapped_appchain_token_beneficiary) =
+            premined_wrapped_appchain_token_beneficiary
+        {
+            metadata.premined_wrapped_appchain_token_beneficiary.clear();
+            metadata
+                .premined_wrapped_appchain_token_beneficiary
+                .push_str(&premined_wrapped_appchain_token_beneficiary);
+        }
         if let Some(premined_wrapped_appchain_token) = premined_wrapped_appchain_token {
             metadata.premined_wrapped_appchain_token = premined_wrapped_appchain_token;
         }
@@ -78,6 +96,9 @@ impl RegistryOwnerActions for AppchainRegistry {
         }
         if let Some(initial_era_reward) = initial_era_reward {
             metadata.initial_era_reward = initial_era_reward;
+        }
+        if let Some(fungible_token_metadata) = fungible_token_metadata {
+            metadata.fungible_token_metadata = fungible_token_metadata;
         }
         if let Some(custom_metadata) = custom_metadata {
             metadata.custom_metadata.clear();

--- a/appchain-registry/src/types.rs
+++ b/appchain-registry/src/types.rs
@@ -26,13 +26,16 @@ pub struct RegistrySettings {
 #[serde(crate = "near_sdk::serde")]
 pub struct AppchainMetadata {
     pub website_url: String,
+    pub function_spec_url: String,
     pub github_address: String,
     pub github_release: String,
     pub commit_id: String,
     pub contact_email: String,
+    pub premined_wrapped_appchain_token_beneficiary: AccountId,
     pub premined_wrapped_appchain_token: U128,
     pub ido_amount_of_wrapped_appchain_token: U128,
     pub initial_era_reward: U128,
+    pub fungible_token_metadata: FungibleTokenMetadata,
     pub custom_metadata: HashMap<String, String>,
 }
 

--- a/appchain-registry/src/upgradable.rs
+++ b/appchain-registry/src/upgradable.rs
@@ -12,7 +12,7 @@ pub struct OldAppchainMetadata {
     pub github_release: String,
     pub commit_id: String,
     pub contact_email: String,
-    pub preminted_wrapped_appchain_token: U128,
+    pub premined_wrapped_appchain_token: U128,
     pub ido_amount_of_wrapped_appchain_token: U128,
     pub initial_era_reward: U128,
     pub custom_metadata: HashMap<String, String>,

--- a/appchain-registry/tests/appchain_owner_action/mod.rs
+++ b/appchain-registry/tests/appchain_owner_action/mod.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use appchain_registry::AppchainRegistryContract;
 use mock_oct_token::MockOctTokenContract;
-use near_sdk::serde::{Deserialize, Serialize};
+use near_sdk::{
+    serde::{Deserialize, Serialize},
+    serde_json::json,
+};
 use near_sdk_sim::{call, ContractAccount, ExecutionResult, UserAccount};
 
 use crate::common;
@@ -25,8 +28,36 @@ pub fn register_appchain(
         signer,
         &registry.user_account,
         amount,
-        format!("{{\"RegisterAppchain\":{{\"appchain_id\":\"{}\",\"website_url\":\"http://ddfs.dsdfs\",\"github_address\":\"https://jldfs.yoasdfasd\",\"github_release\":\"v1.0.0\",\"commit_id\":\"commit_id\",\"contact_email\":\"joe@lksdf.com\",\"premined_wrapped_appchain_token\":\"10000000\",\"ido_amount_of_wrapped_appchain_token\":\"1000000\",\"initial_era_reward\":\"100\",\"custom_metadata\":{{\"key1\":\"value1\"}}}}}}", appchain_id),
-        oct_token)
+        json!({
+            "RegisterAppchain":{
+                "appchain_id": appchain_id,
+                "website_url":"http://ddfs.dsdfs",
+                "function_spec_url":"https://testchain.org/function_spec",
+                "github_address":"https://jldfs.yoasdfasd",
+                "github_release":"v1.0.0",
+                "commit_id":"commit_id",
+                "contact_email":"joe@lksdf.com",
+                "premined_wrapped_appchain_token_beneficiary":"bob",
+                "premined_wrapped_appchain_token":"10000000",
+                "ido_amount_of_wrapped_appchain_token":"1000000",
+                "initial_era_reward":"100",
+                "fungible_token_metadata":{
+                    "spec":"ft-1.0.0",
+                    "name":"joeToken",
+                    "symbol":"JOT",
+                    "icon":null,
+                    "reference":null,
+                    "reference_hash":null,
+                    "decimals":18
+                },
+                "custom_metadata":{
+                    "key1":"value1"
+                }
+            }
+        })
+        .to_string(),
+        oct_token,
+    )
 }
 
 pub fn transfer_appchain_ownership(

--- a/appchain-registry/tests/registry_owner_action/mod.rs
+++ b/appchain-registry/tests/registry_owner_action/mod.rs
@@ -1,5 +1,6 @@
 use appchain_registry::AppchainRegistryContract;
-use near_sdk::{json_types::U128, Timestamp};
+use near_contract_standards::fungible_token::metadata::FungibleTokenMetadata;
+use near_sdk::{json_types::U128, AccountId, Timestamp};
 use std::collections::HashMap;
 
 use near_sdk_sim::{call, ContractAccount, ExecutionResult, UserAccount};
@@ -11,13 +12,16 @@ pub fn update_appchain_metadata(
     registry: &ContractAccount<AppchainRegistryContract>,
     appchain_id: &String,
     website_url: Option<String>,
+    function_spec_url: Option<String>,
     github_address: Option<String>,
     github_release: Option<String>,
     commit_id: Option<String>,
     contact_email: Option<String>,
+    premined_wrapped_appchain_token_beneficiary: Option<AccountId>,
     premined_wrapped_appchain_token: Option<U128>,
     ido_amount_of_wrapped_appchain_token: Option<U128>,
     initial_era_reward: Option<U128>,
+    fungible_token_metadata: Option<FungibleTokenMetadata>,
     custom_metadata: Option<HashMap<String, String>>,
 ) -> ExecutionResult {
     let outcome = call!(
@@ -25,13 +29,16 @@ pub fn update_appchain_metadata(
         registry.update_appchain_metadata(
             appchain_id.clone(),
             website_url,
+            function_spec_url,
             github_address,
             github_release,
             commit_id,
             contact_email,
+            premined_wrapped_appchain_token_beneficiary,
             premined_wrapped_appchain_token,
             ido_amount_of_wrapped_appchain_token,
             initial_era_reward,
+            fungible_token_metadata,
             custom_metadata
         )
     );

--- a/appchain-registry/tests/registry_viewer/mod.rs
+++ b/appchain-registry/tests/registry_viewer/mod.rs
@@ -10,6 +10,9 @@ pub fn get_registry_settings(
     registry: &ContractAccount<AppchainRegistryContract>,
 ) -> RegistrySettings {
     let view_result = view!(registry.get_registry_settings());
+    if view_result.is_err() {
+        println!("{:#?}", view_result);
+    }
     assert!(view_result.is_ok());
     view_result.unwrap_json::<RegistrySettings>()
 }
@@ -29,6 +32,9 @@ pub fn print_appchains(
         sorting_field,
         sorting_order
     ));
+    if view_result.is_err() {
+        println!("{:#?}", view_result);
+    }
     assert!(view_result.is_ok());
     println!("{}", String::from_utf8(view_result.unwrap()).unwrap());
     let appchains: Vec<AppchainStatus> = view_result.unwrap_json();
@@ -40,6 +46,9 @@ pub fn get_appchain_status(
     appchain_id: &String,
 ) -> AppchainStatus {
     let view_result = view!(registry.get_appchain_status_of(appchain_id.clone()));
+    if view_result.is_err() {
+        println!("{:#?}", view_result);
+    }
     assert!(view_result.is_ok());
     println!("{}", String::from_utf8(view_result.unwrap()).unwrap());
     let appchain_status: AppchainStatus = view_result.unwrap_json();
@@ -53,6 +62,10 @@ pub fn get_upvote_deposit_of(
 ) -> U128 {
     let view_result =
         view!(registry.get_upvote_deposit_for(appchain_id.clone(), user.account_id()));
+    if view_result.is_err() {
+        println!("{:#?}", view_result);
+    }
+    assert!(view_result.is_ok());
     view_result.unwrap_json::<U128>()
 }
 
@@ -63,5 +76,9 @@ pub fn get_downvote_deposit_of(
 ) -> U128 {
     let view_result =
         view!(registry.get_downvote_deposit_for(appchain_id.clone(), user.account_id()));
+    if view_result.is_err() {
+        println!("{:#?}", view_result);
+    }
+    assert!(view_result.is_ok());
     view_result.unwrap_json::<U128>()
 }

--- a/appchain-registry/tests/test_registry_actions.rs
+++ b/appchain-registry/tests/test_registry_actions.rs
@@ -130,10 +130,13 @@ fn test_case1() {
         Option::None,
         Option::None,
         Option::None,
+        Option::None,
         Option::from(String::from("yangzhen@oct.network")),
+        Option::None,
         Option::from(U128::from(10_000_000_000_000_000_000_000_000)),
         Option::from(U128::from(1_000_000_000_000_000_000_000_000)),
         Option::from(U128::from(100_000_000_000_000_000_000)),
+        Option::None,
         Option::from(custom_metadata.clone()),
     );
     assert!(!outcome.is_ok());
@@ -145,10 +148,13 @@ fn test_case1() {
         Option::None,
         Option::None,
         Option::None,
+        Option::None,
         Option::from(String::from("yangzhen@oct.network")),
+        Option::None,
         Option::from(U128::from(10_000_000_000_000_000_000_000_000)),
         Option::from(U128::from(1_000_000_000_000_000_000_000_000)),
         Option::from(U128::from(100_000_000_000_000_000_000)),
+        Option::None,
         Option::from(custom_metadata.clone()),
     );
     outcome.assert_success();


### PR DESCRIPTION
In this pr, we add some necessary fields in appchain registration:

* `function_spec_url`
* `premined_wrapped_appchain_token_beneficiary`
* `fungible_token_metadata`

The `fungible_token_metadata` is the metadata of wrapped appchain token of corresponding appchain. The token is managed by a NEP-141 compatible contract. And the metadata will be used to initialize the token contract. It is defined in [near-sdk-rs v3.1.0](https://github.com/near/near-sdk-rs/blob/3.1.0/near-contract-standards/src/fungible_token/metadata.rs).
