### PR TITLE
Upgrade to v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "actix"
-version = "0.11.0-beta.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb78f9871feb3519e06b947c2becbf2cc7f67ce786e510e6bd3f9a27da3dbf1"
+checksum = "f728064aca1c318585bf4bb04ffcfac9e75e508ab4e8b1bd9ba5dfe04e2cbed5"
 dependencies = [
  "actix-rt",
  "actix_derive",
@@ -22,13 +22,14 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-task",
+ "futures-util",
  "log",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-project-lite",
  "smallvec",
  "tokio",
- "tokio-util 0.6.10",
+ "tokio-util",
 ]
 
 [[package]]
@@ -43,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "actix_derive"
-version = "0.6.0-beta.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae749cf2582eb83efd288edd4e9704600fdce1bc4f69aa0c86ca1368a3e4c13f"
+checksum = "6d44b8fee1ced9671ba043476deddef739dd0959bf77030b26b738cc591737a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -970,7 +971,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tracing",
 ]
 
@@ -981,15 +982,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1315,16 +1307,6 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b81ee2cf429b8bc04046d94f725a4f192fe7b13f42d76649d0177fd9ea719d8"
-dependencies = [
- "borsh",
- "serde",
-]
-
-[[package]]
-name = "near-account-id"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de83d74a9241be8cc4eb3055216966b58bf8c463e8e285c0dc553925acdd19fa"
@@ -1334,63 +1316,74 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-chain-configs"
-version = "0.12.0"
+name = "near-account-id"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a830a8ea64328e4d2553873df848a97a90d111cb838ff5e199bfce79b62b6c2b"
+checksum = "71d258582a1878e6db67400b0504a5099db85718d22c2e07f747fe1706ae7150"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "near-chain-configs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3632a1c691603cb32dd9944c95d8eadbf2c09f45abd95350ea6848c649036a0b"
 dependencies = [
  "anyhow",
  "chrono",
  "derive_more",
- "near-crypto 0.12.0",
- "near-primitives 0.12.0",
+ "near-crypto 0.14.0",
+ "near-primitives 0.14.0",
  "num-rational",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "smart-default",
  "tracing",
 ]
 
 [[package]]
 name = "near-chain-primitives"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7984007ab1c73f101c5acf60a1e1f86a4afd47048df1e2412d4501794b43da"
+checksum = "a734353027698b21633a49d478e564c61ae0171c32f6912bb8844add15d72ebe"
 dependencies = [
  "chrono",
- "failure",
- "failure_derive",
- "log",
- "near-crypto 0.12.0",
- "near-primitives 0.12.0",
+ "near-crypto 0.14.0",
+ "near-primitives 0.14.0",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "near-chunks-primitives"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838c06b137c7452001fc826f2defa6328b2695aaa720df2f0d08e31e54f849f6"
+checksum = "c17f6f22f1ab710731dfba4101f12a99cac120d6af80b99899bd335bb8971477"
 dependencies = [
  "near-chain-primitives",
+ "near-primitives 0.14.0",
 ]
 
 [[package]]
 name = "near-client-primitives"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc73ebfbb59defac9a17883467af98a14a37f53079dbcbdeec57c37d329de2b"
+checksum = "e1065d86012eeea838661434549f33bb6267c9950fd2aadd2af617fe773def38"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 0.12.0",
+ "near-crypto 0.14.0",
  "near-network-primitives",
- "near-primitives 0.12.0",
- "strum 0.20.0",
+ "near-primitives 0.14.0",
+ "serde",
+ "serde_json",
+ "strum",
  "thiserror",
 ]
 
@@ -1403,33 +1396,6 @@ dependencies = [
  "near-sdk",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "near-crypto"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d301d3ca4f59ab69c4b8ff625e7b2ef624345f69ab651d15c5fd59382096d2b1"
-dependencies = [
- "arrayref",
- "blake2",
- "borsh",
- "bs58",
- "c2-chacha",
- "curve25519-dalek",
- "derive_more",
- "ed25519-dalek",
- "libc",
- "near-account-id 0.12.0",
- "once_cell",
- "parity-secp256k1",
- "primitive-types",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "serde",
- "serde_json",
- "subtle",
- "thiserror",
 ]
 
 [[package]]
@@ -1460,16 +1426,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-jsonrpc-client"
-version = "0.3.0"
+name = "near-crypto"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf00d43006d0768aba1ff4d24386192a7aed2ad7548e9301055b6494917b2cc7"
+checksum = "1e75673d69fd7365508f3d32483669fe45b03bfb34e4d9363e90adae9dfb416c"
+dependencies = [
+ "arrayref",
+ "blake2",
+ "borsh",
+ "bs58",
+ "c2-chacha",
+ "curve25519-dalek",
+ "derive_more",
+ "ed25519-dalek",
+ "near-account-id 0.14.0",
+ "once_cell",
+ "parity-secp256k1",
+ "primitive-types",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "near-jsonrpc-client"
+version = "0.4.0-beta.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba462f54bc35289a1013ed3a2ebfa67cc8b12699f81c12dd67687f200c7b871"
 dependencies = [
  "borsh",
  "lazy_static",
+ "log",
  "near-chain-configs",
+ "near-crypto 0.14.0",
  "near-jsonrpc-primitives",
- "near-primitives 0.12.0",
+ "near-primitives 0.14.0",
  "reqwest",
  "serde",
  "serde_json",
@@ -1479,80 +1473,37 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e636f8862e0f5f565fb02b752e16aa676fc684e81682bfbb39a964defea627"
+checksum = "34a14ee8ca393c0140cb232789259ebc61b13b4cceb177267d0131f50d0eda6c"
 dependencies = [
- "actix",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 0.12.0",
- "near-metrics",
- "near-network-primitives",
- "near-primitives 0.12.0",
- "near-primitives-core 0.12.0",
- "near-rpc-error-macro 0.12.0",
- "once_cell",
+ "near-crypto 0.14.0",
+ "near-primitives 0.14.0",
+ "near-rpc-error-macro 0.14.0",
  "serde",
  "serde_json",
  "thiserror",
- "tracing",
  "uuid",
 ]
 
 [[package]]
-name = "near-metrics"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df4074b56b24c73073b576bc27133182c8654d414be09ef666ad1e1d5ea8adb"
-dependencies = [
- "lazy_static",
- "log",
- "prometheus",
-]
-
-[[package]]
 name = "near-network-primitives"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63ddab6f0376a0ce870947e1ea2e98eba746af2e7edfba5dc127bbd2a2508d6"
+checksum = "5aa998a1e70ebf8cf3efa76c4562ef36038cc88b4aee60efb708d14273910357"
 dependencies = [
  "actix",
- "actix_derive",
  "anyhow",
  "borsh",
  "chrono",
- "near-crypto 0.12.0",
- "near-primitives 0.12.0",
- "strum 0.20.0",
+ "near-crypto 0.14.0",
+ "near-primitives 0.14.0",
+ "serde",
+ "strum",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "near-primitives"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6a0b49d322ebda81ec4fdd99dca804526539673d0b12133286e0d7934f4802"
-dependencies = [
- "borsh",
- "byteorder",
- "bytesize",
- "chrono",
- "derive_more",
- "easy-ext",
- "hex 0.4.3",
- "near-crypto 0.12.0",
- "near-primitives-core 0.12.0",
- "near-rpc-error-macro 0.12.0",
- "near-vm-errors 0.12.0",
- "num-rational",
- "primitive-types",
- "rand 0.7.3",
- "reed-solomon-erasure",
- "serde",
- "serde_json",
- "smart-default",
 ]
 
 [[package]]
@@ -1580,24 +1531,37 @@ dependencies = [
  "serde",
  "serde_json",
  "smart-default",
- "strum 0.24.0",
+ "strum",
  "thiserror",
 ]
 
 [[package]]
-name = "near-primitives-core"
-version = "0.12.0"
+name = "near-primitives"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaae2d2271ecdb0e3d90c11724cdb46d7d5bb50838fdb3941bfc381634cf08a3"
+checksum = "8ad1a9a1640539c81f065425c31bffcfbf6b31ef1aeaade59ce905f5df6ac860"
 dependencies = [
- "base64 0.11.0",
  "borsh",
- "bs58",
+ "byteorder",
+ "bytesize",
+ "chrono",
  "derive_more",
- "near-account-id 0.12.0",
+ "easy-ext",
+ "hex 0.4.3",
+ "near-crypto 0.14.0",
+ "near-primitives-core 0.14.0",
+ "near-rpc-error-macro 0.14.0",
+ "near-vm-errors 0.14.0",
  "num-rational",
+ "once_cell",
+ "primitive-types",
+ "rand 0.7.3",
+ "reed-solomon-erasure",
  "serde",
- "sha2 0.9.9",
+ "serde_json",
+ "smart-default",
+ "strum",
+ "thiserror",
 ]
 
 [[package]]
@@ -1614,18 +1578,24 @@ dependencies = [
  "num-rational",
  "serde",
  "sha2 0.10.2",
- "strum 0.24.0",
+ "strum",
 ]
 
 [[package]]
-name = "near-rpc-error-core"
-version = "0.12.0"
+name = "near-primitives-core"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b9fd54b177a2efc1203cd605dc3369289d9c2a74ddbfdfb372feb13be38060"
+checksum = "91d508f0fc340f6461e4e256417685720d3c4c00bb5a939b105160e49137caba"
 dependencies = [
- "quote",
+ "base64 0.11.0",
+ "borsh",
+ "bs58",
+ "derive_more",
+ "near-account-id 0.14.0",
+ "num-rational",
  "serde",
- "syn",
+ "sha2 0.10.2",
+ "strum",
 ]
 
 [[package]]
@@ -1640,12 +1610,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-rpc-error-macro"
-version = "0.12.0"
+name = "near-rpc-error-core"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38f5469f86f3c8ce0f39828f10a9c6aca2581d71a5c176a1c9be7e7eb4511a3"
+checksum = "93ee0b41c75ef859c193a8ff1dadfa0c8207bc0ac447cc22259721ad769a1408"
 dependencies = [
- "near-rpc-error-core 0.12.0",
+ "quote",
  "serde",
  "syn",
 ]
@@ -1662,10 +1632,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sandbox-utils"
-version = "0.2.0"
+name = "near-rpc-error-macro"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a543af5c633d7351ff92bbb523f040ffd393b7460d10ee7478282221a57abcf"
+checksum = "8e837bd4bacd807073ec5ceb85708da7f721b46a4c2a978de86027fb0034ce31"
+dependencies = [
+ "near-rpc-error-core 0.14.0",
+ "serde",
+ "syn",
+]
+
+[[package]]
+name = "near-sandbox-utils"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafbc6e0f88ba3c4dd41d947d6ef86367dc2d9b5e0112bde1a5ae8251a71b4f7"
 dependencies = [
  "anyhow",
  "async-process",
@@ -1747,18 +1728,6 @@ dependencies = [
 
 [[package]]
 name = "near-vm-errors"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5092bbad4e16e48423d9be92e18b84af8e128c263df66d867a3f99c560b3cb28"
-dependencies = [
- "borsh",
- "near-account-id 0.12.0",
- "near-rpc-error-macro 0.12.0",
- "serde",
-]
-
-[[package]]
-name = "near-vm-errors"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e02faf2bc1f6ef82b965cfe44389808fb5594f7aca4b596766117f4ce74df20"
@@ -1766,6 +1735,18 @@ dependencies = [
  "borsh",
  "near-account-id 0.13.0",
  "near-rpc-error-macro 0.13.0",
+ "serde",
+]
+
+[[package]]
+name = "near-vm-errors"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0da466a30f0446639cbd788c30865086fac3e8dcb07a79e51d2b0775ed4261e"
+dependencies = [
+ "borsh",
+ "near-account-id 0.14.0",
+ "near-rpc-error-macro 0.14.0",
  "serde",
 ]
 
@@ -1971,37 +1952,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall 0.2.13",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2127,27 +2083,6 @@ checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
-
-[[package]]
-name = "prometheus"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8425533e7122f0c3cc7a37e6244b16ad3a2cc32ae7ac6276e2a75da0d9c200d"
-dependencies = [
- "cfg-if 1.0.0",
- "fnv",
- "lazy_static",
- "parking_lot 0.11.2",
- "protobuf",
- "regex",
- "thiserror",
-]
-
-[[package]]
-name = "protobuf"
-version = "2.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "quote"
@@ -2593,32 +2528,11 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
-dependencies = [
- "strum_macros 0.20.1",
-]
-
-[[package]]
-name = "strum"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
 dependencies = [
- "strum_macros 0.24.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]
@@ -2627,7 +2541,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2751,7 +2665,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2788,20 +2702,6 @@ checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
  "rand 0.8.5",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -2904,12 +2804,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-xid"
@@ -3158,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "workspaces"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a9b9b6d29ca216ce56e738450ac32016466fe626e1a10732e0f01092ce2f66"
+checksum = "c8b8e4bc0367196fe6386e2c2325c13ee36066392682142d485237e355350e26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3170,11 +3064,11 @@ dependencies = [
  "dirs 3.0.2",
  "hex 0.4.3",
  "libc",
- "near-account-id 0.12.0",
- "near-crypto 0.12.0",
+ "near-account-id 0.14.0",
+ "near-crypto 0.14.0",
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
- "near-primitives 0.12.0",
+ "near-primitives 0.14.0",
  "near-sandbox-utils",
  "portpicker",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "appchain-registry"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "hex 0.4.3",
  "near-contract-standards",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "appchain-registry-wrapper"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "appchain-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appchain-registry-wrapper"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Octopus Network"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ appchain-registry = { path = "./appchain-registry" }
 mock-oct-token = { path = "./mock-oct-token" }
 mock-appchain-anchor = { path = "./mock-appchain-anchor" }
 tokio = { version = "1.14", features = ["full"] }
-workspaces = "0.3"
+workspaces = "0.4"
 
 [profile.release]
 codegen-units = 1

--- a/appchain-registry/Cargo.toml
+++ b/appchain-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appchain-registry"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Octopus Network"]
 edition = "2021"
 

--- a/appchain-registry/src/appchain_basedata.rs
+++ b/appchain-registry/src/appchain_basedata.rs
@@ -1,11 +1,9 @@
-use std::convert::TryInto;
-
-use near_sdk::collections::LazyOption;
-use near_sdk::Timestamp;
-use near_sdk::json_types::U64;
-
 use crate::types::{AppchainMetadata, AppchainState, AppchainStatus};
 use crate::*;
+use near_sdk::collections::LazyOption;
+use near_sdk::json_types::U64;
+use near_sdk::Timestamp;
+use std::convert::TryInto;
 
 /// Appchain basedata
 #[derive(BorshDeserialize, BorshSerialize)]

--- a/appchain-registry/src/appchain_basedata.rs
+++ b/appchain-registry/src/appchain_basedata.rs
@@ -10,6 +10,7 @@ use crate::*;
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct AppchainBasedata {
     pub appchain_id: AppchainId,
+    pub appchain_chain_id: Option<u32>,
     pub appchain_metadata: LazyOption<AppchainMetadata>,
     pub appchain_anchor: Option<AccountId>,
     pub appchain_owner: AccountId,
@@ -27,12 +28,14 @@ impl AppchainBasedata {
     /// Return a new instance of AppchainBasedata with the given parameters
     pub fn new(
         appchain_id: AppchainId,
+        appchain_chain_id: Option<u32>,
         appchain_metadata: AppchainMetadata,
         appchain_owner: AccountId,
         register_deposit: Balance,
     ) -> Self {
         Self {
             appchain_id: appchain_id.clone(),
+            appchain_chain_id,
             appchain_metadata: LazyOption::new(
                 StorageKey::AppchainMetadata(appchain_id.clone()).into_bytes(),
                 Some(&appchain_metadata),
@@ -98,6 +101,7 @@ impl AppchainBasedata {
     pub fn status(&self) -> AppchainStatus {
         AppchainStatus {
             appchain_id: self.appchain_id.clone(),
+            appchain_chain_id: self.appchain_chain_id,
             appchain_metadata: self.appchain_metadata.get().unwrap(),
             appchain_anchor: self.appchain_anchor.clone(),
             appchain_owner: self.appchain_owner.clone(),
@@ -117,7 +121,7 @@ impl AppchainBasedata {
         assert_ne!(
             self.appchain_owner,
             new_owner.clone(),
-            "The owner not changed."
+            "The owner is not changed."
         );
         self.appchain_owner = new_owner;
     }

--- a/appchain-registry/src/appchain_basedata.rs
+++ b/appchain-registry/src/appchain_basedata.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use near_sdk::collections::LazyOption;
 use near_sdk::Timestamp;
+use near_sdk::json_types::U64;
 
 use crate::types::{AppchainMetadata, AppchainState, AppchainStatus};
 use crate::*;
@@ -10,7 +11,7 @@ use crate::*;
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct AppchainBasedata {
     pub appchain_id: AppchainId,
-    pub appchain_chain_id: Option<u32>,
+    pub evm_chain_id: Option<U64>,
     pub appchain_metadata: LazyOption<AppchainMetadata>,
     pub appchain_anchor: Option<AccountId>,
     pub appchain_owner: AccountId,
@@ -28,14 +29,14 @@ impl AppchainBasedata {
     /// Return a new instance of AppchainBasedata with the given parameters
     pub fn new(
         appchain_id: AppchainId,
-        appchain_chain_id: Option<u32>,
+        evm_chain_id: Option<U64>,
         appchain_metadata: AppchainMetadata,
         appchain_owner: AccountId,
         register_deposit: Balance,
     ) -> Self {
         Self {
             appchain_id: appchain_id.clone(),
-            appchain_chain_id,
+            evm_chain_id,
             appchain_metadata: LazyOption::new(
                 StorageKey::AppchainMetadata(appchain_id.clone()).into_bytes(),
                 Some(&appchain_metadata),
@@ -101,7 +102,7 @@ impl AppchainBasedata {
     pub fn status(&self) -> AppchainStatus {
         AppchainStatus {
             appchain_id: self.appchain_id.clone(),
-            appchain_chain_id: self.appchain_chain_id,
+            evm_chain_id: self.evm_chain_id,
             appchain_metadata: self.appchain_metadata.get().unwrap(),
             appchain_anchor: self.appchain_anchor.clone(),
             appchain_owner: self.appchain_owner.clone(),

--- a/appchain-registry/src/appchain_lifecycle.rs
+++ b/appchain-registry/src/appchain_lifecycle.rs
@@ -1,4 +1,5 @@
 use crate::{interfaces::AppchainLifecycleManager, types::AppchainId, *};
+use near_sdk::AccountId;
 
 #[near_bindgen]
 impl AppchainLifecycleManager for AppchainRegistry {
@@ -7,6 +8,7 @@ impl AppchainLifecycleManager for AppchainRegistry {
         &mut self,
         appchain_id: AppchainId,
         description: Option<String>,
+        template_type: Option<AppchainTemplateType>,
         website_url: Option<String>,
         function_spec_url: Option<String>,
         github_address: Option<String>,
@@ -24,35 +26,85 @@ impl AppchainLifecycleManager for AppchainRegistry {
         let mut appchain_basedata = self.get_appchain_basedata(&appchain_id);
         let mut metadata = appchain_basedata.metadata();
         if let Some(description) = description {
+            assert!(
+                !metadata.description.eq(&description),
+                "The description is not changed."
+            );
             metadata.description = description;
         }
+        if let Some(template_type) = template_type {
+            assert!(
+                !metadata.template_type.eq(&template_type),
+                "The template type is not changed."
+            );
+            metadata.template_type = template_type;
+        }
         if let Some(website_url) = website_url {
+            assert!(
+                !metadata.website_url.eq(&website_url),
+                "The website url is not changed."
+            );
             metadata.website_url = website_url;
         }
         if let Some(function_spec_url) = function_spec_url {
+            assert!(
+                !metadata.function_spec_url.eq(&function_spec_url),
+                "The function spec url is not changed."
+            );
             metadata.function_spec_url = function_spec_url;
         }
         if let Some(github_address) = github_address {
+            assert!(
+                !metadata.github_address.eq(&github_address),
+                "The github address is not changed."
+            );
             metadata.github_address = github_address;
         }
         if let Some(github_release) = github_release {
+            assert!(
+                !metadata.github_release.eq(&github_release),
+                "The github release is not changed."
+            );
             metadata.github_release = github_release;
         }
         if let Some(contact_email) = contact_email {
+            assert!(
+                !metadata.contact_email.eq(&contact_email),
+                "The contact email is not changed."
+            );
             metadata.contact_email = contact_email;
         }
         if let Some(premined_wrapped_appchain_token_beneficiary) =
             premined_wrapped_appchain_token_beneficiary
         {
+            assert!(
+                !metadata
+                    .premined_wrapped_appchain_token_beneficiary
+                    .map_or(AccountId::new_unchecked("".to_string()), |f| f)
+                    .eq(&premined_wrapped_appchain_token_beneficiary),
+                "The premined wrapped appchain token beneficiary is not changed."
+            );
             metadata.premined_wrapped_appchain_token_beneficiary =
                 Some(premined_wrapped_appchain_token_beneficiary);
         }
         if let Some(premined_wrapped_appchain_token) = premined_wrapped_appchain_token {
+            assert!(
+                !metadata
+                    .premined_wrapped_appchain_token
+                    .eq(&premined_wrapped_appchain_token),
+                "The premined wrapped appchain token is not changed."
+            );
             metadata.premined_wrapped_appchain_token = premined_wrapped_appchain_token;
         }
         if let Some(initial_supply_of_wrapped_appchain_token) =
             initial_supply_of_wrapped_appchain_token
         {
+            assert!(
+                !metadata
+                    .initial_supply_of_wrapped_appchain_token
+                    .eq(&initial_supply_of_wrapped_appchain_token),
+                "The initial supply of wrapped appchain token is not changed."
+            );
             assert!(
                 initial_supply_of_wrapped_appchain_token.0 >= metadata.premined_wrapped_appchain_token.0,
                 "The initial supply of wrapped appchain token should not be less than the premined amount."
@@ -61,9 +113,19 @@ impl AppchainLifecycleManager for AppchainRegistry {
                 initial_supply_of_wrapped_appchain_token;
         }
         if let Some(ido_amount_of_wrapped_appchain_token) = ido_amount_of_wrapped_appchain_token {
+            assert!(
+                !metadata
+                    .ido_amount_of_wrapped_appchain_token
+                    .eq(&ido_amount_of_wrapped_appchain_token),
+                "The ido amount of wrapped appchain token is not changed."
+            );
             metadata.ido_amount_of_wrapped_appchain_token = ido_amount_of_wrapped_appchain_token;
         }
         if let Some(initial_era_reward) = initial_era_reward {
+            assert!(
+                !metadata.initial_era_reward.eq(&initial_era_reward),
+                "The initial era reward is not changed."
+            );
             metadata.initial_era_reward = initial_era_reward;
         }
         if let Some(fungible_token_metadata) = fungible_token_metadata {

--- a/appchain-registry/src/interfaces.rs
+++ b/appchain-registry/src/interfaces.rs
@@ -106,7 +106,7 @@ pub trait SudoActions {
     fn set_owner_pk(&mut self, public_key: String);
     /// Create subaccount for a specific appchain.
     fn create_anchor_account(&mut self, appchain_id: AppchainId);
-    /// Force change state of an appchain
+    /// Force change state of an appchain.
     fn force_change_appchain_state(&mut self, appchain_id: AppchainId, state: AppchainState);
     /// Pause asset transfer in this contract.
     fn pause_asset_transfer(&mut self);
@@ -114,6 +114,8 @@ pub trait SudoActions {
     fn resume_asset_transfer(&mut self);
     /// Set the evm chain id of an appchain.
     fn set_evm_chain_id_of_appchain(&mut self, appchain_id: String, evm_chain_id: U64);
+    /// Force remove an appchain.
+    fn force_remove_appchain(&mut self, appchain_id: AppchainId);
 }
 
 pub trait VoterActions {

--- a/appchain-registry/src/interfaces.rs
+++ b/appchain-registry/src/interfaces.rs
@@ -1,9 +1,8 @@
-use near_sdk::json_types::U64;
-
 use crate::{
     types::{AppchainSortingField, AppchainStatus, SortingOrder},
     *,
 };
+use near_sdk::json_types::U64;
 
 /// The callback interface for appchain anchor
 pub trait AppchainAnchorCallback {
@@ -113,6 +112,8 @@ pub trait SudoActions {
     fn pause_asset_transfer(&mut self);
     /// Resume asset transfer in this contract.
     fn resume_asset_transfer(&mut self);
+    /// Set the evm chain id of an appchain.
+    fn set_evm_chain_id_of_appchain(&mut self, appchain_id: String, evm_chain_id: U64);
 }
 
 pub trait VoterActions {

--- a/appchain-registry/src/interfaces.rs
+++ b/appchain-registry/src/interfaces.rs
@@ -67,6 +67,8 @@ pub trait RegistrySettingsManager {
 
 /// The interface for querying status of appchain registry
 pub trait RegistryStatus {
+    /// Show the version of current contract.
+    fn version(&self) -> String;
     /// Get the public key of current owner
     fn get_owner_pk(&self) -> String;
     /// Get account id of OCT token

--- a/appchain-registry/src/interfaces.rs
+++ b/appchain-registry/src/interfaces.rs
@@ -63,7 +63,7 @@ pub trait RegistrySettingsManager {
     /// Change the interval for counting voting score of appchains
     fn change_counting_interval_in_seconds(&mut self, value: U64);
     /// Change the latest appchain chain id
-    fn change_latest_appchain_chain_id(&mut self, value: u32);
+    fn change_latest_evm_chain_id(&mut self, value: U64);
 }
 
 /// The interface for querying status of appchain registry

--- a/appchain-registry/src/interfaces.rs
+++ b/appchain-registry/src/interfaces.rs
@@ -29,6 +29,7 @@ pub trait AppchainLifecycleManager {
         &mut self,
         appchain_id: AppchainId,
         description: Option<String>,
+        template_type: Option<AppchainTemplateType>,
         website_url: Option<String>,
         function_spec_url: Option<String>,
         github_address: Option<String>,
@@ -61,6 +62,8 @@ pub trait RegistrySettingsManager {
     fn change_voting_result_reduction_percent(&mut self, value: U64);
     /// Change the interval for counting voting score of appchains
     fn change_counting_interval_in_seconds(&mut self, value: U64);
+    /// Change the latest appchain chain id
+    fn change_latest_appchain_chain_id(&mut self, value: u32);
 }
 
 /// The interface for querying status of appchain registry

--- a/appchain-registry/src/lib.rs
+++ b/appchain-registry/src/lib.rs
@@ -384,6 +384,10 @@ impl AppchainRegistry {
         );
         assert!(appchain_id.find(".").is_none(), "Invalid 'appchain_id'.");
         assert!(
+            appchain_id.len() <= 20,
+            "Appchain id is too long (max length is 20)."
+        );
+        assert!(
             AccountId::try_from(format!("{}.{}", appchain_id, env::current_account_id())).is_ok(),
             "Invalid 'appchain_id'."
         );

--- a/appchain-registry/src/lib.rs
+++ b/appchain-registry/src/lib.rs
@@ -34,6 +34,7 @@ use types::{
     RegistrySettings,
 };
 
+const VERSION: &str = "v2.1.0";
 /// Initial balance for the AppchainAnchor contract to cover storage and related.
 const APPCHAIN_ANCHOR_INIT_BALANCE: Balance = 26_000_000_000_000_000_000_000_000;
 const T_GAS_FOR_RESOLVER_FUNCTION: u64 = 10;

--- a/appchain-registry/src/lib.rs
+++ b/appchain-registry/src/lib.rs
@@ -7,7 +7,7 @@ mod registry_roles;
 mod registry_settings;
 mod registry_status;
 mod storage_key;
-mod storage_migration;
+pub mod storage_migration;
 mod sudo_actions;
 pub mod types;
 mod upgrade;
@@ -29,7 +29,10 @@ use near_sdk::{
 
 use appchain_basedata::AppchainBasedata;
 use storage_key::StorageKey;
-use types::{AppchainId, AppchainMetadata, AppchainState, RegistryRoles, RegistrySettings};
+use types::{
+    AppchainId, AppchainMetadata, AppchainState, AppchainTemplateType, RegistryRoles,
+    RegistrySettings,
+};
 
 /// Initial balance for the AppchainAnchor contract to cover storage and related.
 const APPCHAIN_ANCHOR_INIT_BALANCE: Balance = 26_000_000_000_000_000_000_000_000;
@@ -108,6 +111,7 @@ enum RegistryDepositMessage {
     RegisterAppchain {
         appchain_id: String,
         description: String,
+        template_type: AppchainTemplateType,
         website_url: String,
         function_spec_url: String,
         github_address: String,
@@ -263,6 +267,7 @@ impl AppchainRegistry {
             RegistryDepositMessage::RegisterAppchain {
                 appchain_id,
                 description,
+                template_type,
                 website_url,
                 function_spec_url,
                 github_address,
@@ -280,6 +285,7 @@ impl AppchainRegistry {
                     sender_id,
                     appchain_id,
                     description,
+                    template_type,
                     amount.0,
                     website_url,
                     function_spec_url,
@@ -340,6 +346,7 @@ impl AppchainRegistry {
         sender_id: AccountId,
         appchain_id: AppchainId,
         description: String,
+        template_type: AppchainTemplateType,
         register_deposit: Balance,
         website_url: String,
         function_spec_url: String,
@@ -413,10 +420,21 @@ impl AppchainRegistry {
             initial_supply_of_wrapped_appchain_token.0 >= premined_wrapped_appchain_token.0,
             "The initial supply of wrapped appchain token should not be less than the premined amount."
         );
+        let mut registry_settings = self.registry_settings.get().unwrap();
+        let appchain_chain_id = match template_type {
+            AppchainTemplateType::Barnacle => None,
+            AppchainTemplateType::BarnacleEvm => {
+                registry_settings.latest_appchain_chain_id += 1;
+                self.registry_settings.set(&registry_settings);
+                Some(registry_settings.latest_appchain_chain_id + 1)
+            }
+        };
         let appchain_basedata = AppchainBasedata::new(
             appchain_id.clone(),
+            appchain_chain_id,
             AppchainMetadata {
                 description,
+                template_type,
                 website_url,
                 function_spec_url,
                 github_address,

--- a/appchain-registry/src/lib.rs
+++ b/appchain-registry/src/lib.rs
@@ -20,7 +20,7 @@ use near_contract_standards::fungible_token::metadata::FungibleTokenMetadata;
 use near_contract_standards::upgrade::Ownable;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::{LazyOption, LookupMap, UnorderedSet};
-use near_sdk::json_types::U128;
+use near_sdk::json_types::{U128, U64};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{
     assert_self, env, ext_contract, log, near_bindgen, serde_json, AccountId, Balance, Duration,
@@ -421,17 +421,18 @@ impl AppchainRegistry {
             "The initial supply of wrapped appchain token should not be less than the premined amount."
         );
         let mut registry_settings = self.registry_settings.get().unwrap();
-        let appchain_chain_id = match template_type {
+        let evm_chain_id = match template_type {
             AppchainTemplateType::Barnacle => None,
             AppchainTemplateType::BarnacleEvm => {
-                registry_settings.latest_appchain_chain_id += 1;
+                registry_settings.latest_evm_chain_id =
+                    U64::from(registry_settings.latest_evm_chain_id.0 + 1);
                 self.registry_settings.set(&registry_settings);
-                Some(registry_settings.latest_appchain_chain_id + 1)
+                Some(registry_settings.latest_evm_chain_id)
             }
         };
         let appchain_basedata = AppchainBasedata::new(
             appchain_id.clone(),
-            appchain_chain_id,
+            evm_chain_id,
             AppchainMetadata {
                 description,
                 template_type,

--- a/appchain-registry/src/registry_settings.rs
+++ b/appchain-registry/src/registry_settings.rs
@@ -10,7 +10,7 @@ impl Default for RegistrySettings {
             minimum_register_deposit: U128::from(DEFAULT_REGISTER_DEPOSIT * OCT_DECIMALS_BASE),
             voting_result_reduction_percent: DEFAULT_VOTING_RESULT_REDUCTION_PERCENT,
             counting_interval_in_seconds: U64::from(SECONDS_OF_A_DAY),
-            latest_appchain_chain_id: 7900,
+            latest_evm_chain_id: U64::from(7900),
         }
     }
 }
@@ -44,10 +44,10 @@ impl RegistrySettingsManager for AppchainRegistry {
         self.registry_settings.set(&registry_settings);
     }
     //
-    fn change_latest_appchain_chain_id(&mut self, value: u32) {
+    fn change_latest_evm_chain_id(&mut self, value: U64) {
         self.assert_registry_settings_manager();
         let mut registry_settings = self.registry_settings.get().unwrap();
-        registry_settings.latest_appchain_chain_id = value;
+        registry_settings.latest_evm_chain_id = value;
         self.registry_settings.set(&registry_settings);
     }
 }

--- a/appchain-registry/src/registry_settings.rs
+++ b/appchain-registry/src/registry_settings.rs
@@ -10,6 +10,7 @@ impl Default for RegistrySettings {
             minimum_register_deposit: U128::from(DEFAULT_REGISTER_DEPOSIT * OCT_DECIMALS_BASE),
             voting_result_reduction_percent: DEFAULT_VOTING_RESULT_REDUCTION_PERCENT,
             counting_interval_in_seconds: U64::from(SECONDS_OF_A_DAY),
+            latest_appchain_chain_id: 7900,
         }
     }
 }
@@ -40,6 +41,13 @@ impl RegistrySettingsManager for AppchainRegistry {
         assert!(value.0 > 3600, "Too short interval.");
         let mut registry_settings = self.registry_settings.get().unwrap();
         registry_settings.counting_interval_in_seconds = value;
+        self.registry_settings.set(&registry_settings);
+    }
+    //
+    fn change_latest_appchain_chain_id(&mut self, value: u32) {
+        self.assert_registry_settings_manager();
+        let mut registry_settings = self.registry_settings.get().unwrap();
+        registry_settings.latest_appchain_chain_id = value;
         self.registry_settings.set(&registry_settings);
     }
 }

--- a/appchain-registry/src/registry_status.rs
+++ b/appchain-registry/src/registry_status.rs
@@ -9,6 +9,10 @@ use crate::{
 #[near_bindgen]
 impl RegistryStatus for AppchainRegistry {
     //
+    fn version(&self) -> String {
+        VERSION.to_string()
+    }
+    //
     fn get_owner_pk(&self) -> String {
         format!("{:?}", self.owner_pk)
     }

--- a/appchain-registry/src/storage_migration.rs
+++ b/appchain-registry/src/storage_migration.rs
@@ -143,7 +143,7 @@ impl AppchainBasedata {
     pub fn from_old_version(old_version: OldAppchainBasedata) -> Self {
         Self {
             appchain_id: old_version.appchain_id.clone(),
-            appchain_chain_id: None,
+            evm_chain_id: None,
             appchain_metadata: LazyOption::new(
                 StorageKey::AppchainMetadata(old_version.appchain_id.clone()).into_bytes(),
                 Some(&AppchainMetadata::from_old_version(
@@ -170,7 +170,7 @@ impl RegistrySettings {
             minimum_register_deposit: old_version.minimum_register_deposit,
             voting_result_reduction_percent: old_version.voting_result_reduction_percent,
             counting_interval_in_seconds: old_version.counting_interval_in_seconds,
-            latest_appchain_chain_id: 7900,
+            latest_evm_chain_id: U64::from(7900),
         }
     }
 }

--- a/appchain-registry/src/sudo_actions.rs
+++ b/appchain-registry/src/sudo_actions.rs
@@ -1,6 +1,5 @@
-use std::{convert::TryFrom, str::FromStr};
-
 use crate::{interfaces::SudoActions, *};
+use std::{convert::TryFrom, str::FromStr};
 
 #[near_bindgen]
 impl SudoActions for AppchainRegistry {
@@ -48,5 +47,16 @@ impl SudoActions for AppchainRegistry {
     fn resume_asset_transfer(&mut self) {
         self.assert_owner();
         self.asset_transfer_is_paused = false;
+    }
+    //
+    fn set_evm_chain_id_of_appchain(&mut self, appchain_id: String, evm_chain_id: U64) {
+        self.assert_owner();
+        if let Some(mut appchain_basedata) = self.appchain_basedatas.get(&appchain_id) {
+            appchain_basedata.evm_chain_id = Some(evm_chain_id);
+            self.appchain_basedatas
+                .insert(&appchain_id, &appchain_basedata);
+        } else {
+            panic!("Appchain id is not existed.");
+        }
     }
 }

--- a/appchain-registry/src/sudo_actions.rs
+++ b/appchain-registry/src/sudo_actions.rs
@@ -59,4 +59,19 @@ impl SudoActions for AppchainRegistry {
             panic!("Appchain id is not existed.");
         }
     }
+    fn force_remove_appchain(&mut self, appchain_id: AppchainId) {
+        self.assert_owner();
+        self.assert_appchain_state(&appchain_id, AppchainState::Dead);
+        let appchain_basedata = self.get_appchain_basedata(&appchain_id);
+        if !appchain_basedata.anchor().is_none() {
+            let anchor_account_id = format!("{}.{}", &appchain_id, env::current_account_id());
+            log!(
+                "The anchor contract '{}' of appchain '{}' needs to be removed manually.",
+                &anchor_account_id,
+                &appchain_id
+            );
+        }
+        self.internal_remove_appchain(&appchain_id);
+        log!("Appchain '{}' is removed from registry.", &appchain_id);
+    }
 }

--- a/appchain-registry/src/types.rs
+++ b/appchain-registry/src/types.rs
@@ -17,6 +17,8 @@ pub struct RegistrySettings {
     /// The interval for calling function `count_voting_score`,
     /// in the interval this function can only be called once.
     pub counting_interval_in_seconds: U64,
+    ///
+    pub latest_appchain_chain_id: u32,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]
@@ -30,11 +32,19 @@ pub struct RegistryRoles {
     pub operator_of_counting_voting_score: Option<AccountId>,
 }
 
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(crate = "near_sdk::serde")]
+pub enum AppchainTemplateType {
+    Barnacle,
+    BarnacleEvm,
+}
+
 /// Appchain metadata
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]
 #[serde(crate = "near_sdk::serde")]
 pub struct AppchainMetadata {
     pub description: String,
+    pub template_type: AppchainTemplateType,
     pub website_url: String,
     pub function_spec_url: String,
     pub github_address: String,
@@ -70,6 +80,7 @@ pub enum AppchainState {
 #[serde(crate = "near_sdk::serde")]
 pub struct AppchainStatus {
     pub appchain_id: AppchainId,
+    pub appchain_chain_id: Option<u32>,
     pub appchain_metadata: AppchainMetadata,
     pub appchain_anchor: Option<AccountId>,
     pub appchain_owner: AccountId,

--- a/appchain-registry/src/types.rs
+++ b/appchain-registry/src/types.rs
@@ -18,7 +18,7 @@ pub struct RegistrySettings {
     /// in the interval this function can only be called once.
     pub counting_interval_in_seconds: U64,
     ///
-    pub latest_appchain_chain_id: u32,
+    pub latest_evm_chain_id: U64,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]
@@ -80,7 +80,7 @@ pub enum AppchainState {
 #[serde(crate = "near_sdk::serde")]
 pub struct AppchainStatus {
     pub appchain_id: AppchainId,
-    pub appchain_chain_id: Option<u32>,
+    pub evm_chain_id: Option<U64>,
     pub appchain_metadata: AppchainMetadata,
     pub appchain_anchor: Option<AccountId>,
     pub appchain_owner: AccountId,

--- a/scripts/cli-samples/update_self_mainnet.sh
+++ b/scripts/cli-samples/update_self_mainnet.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+#
+export NEAR_ENV=mainnet
+#
+export REGISTRY_ACCOUNT_ID=octopus-registry.near
+#
+WASM_BYTES='cat res/appchain_registry.wasm | base64'
+near call $REGISTRY_ACCOUNT_ID store_wasm_of_self $(eval "$WASM_BYTES") --base64 --accountId $REGISTRY_ACCOUNT_ID --deposit 5 --gas 200000000000000
+near call $REGISTRY_ACCOUNT_ID update_self '' --accountId $REGISTRY_ACCOUNT_ID --gas 200000000000000

--- a/tests/simulator/common/basic_actions.rs
+++ b/tests/simulator/common/basic_actions.rs
@@ -11,7 +11,7 @@ pub async fn initialize_contracts_and_users(
     total_supply: u128,
     with_old_anchor: bool,
 ) -> anyhow::Result<(Account, Contract, Contract, Vec<Account>)> {
-    let root = worker.root_account();
+    let root = worker.root_account().unwrap();
     let mut users: Vec<Account> = Vec::new();
     //
     // deploy OCT token contract
@@ -58,7 +58,7 @@ pub async fn initialize_contracts_and_users(
         true => appchain_registry
             .deploy(
                 worker,
-                &std::fs::read(format!("res/previous_appchain_registry.wasm"))?,
+                &std::fs::read(format!("res/appchain_registry_v2.0.0.wasm"))?,
             )
             .await?
             .unwrap(),

--- a/tests/simulator/contract_interfaces/appchain_owner_actions.rs
+++ b/tests/simulator/contract_interfaces/appchain_owner_actions.rs
@@ -1,4 +1,5 @@
 use crate::common;
+use appchain_registry::types::AppchainTemplateType;
 use near_contract_standards::fungible_token::metadata::FungibleTokenMetadata;
 use near_sdk::{
     json_types::U128,
@@ -23,6 +24,7 @@ pub async fn register_appchain(
     registry: &Contract,
     appchain_id: &String,
     description: Option<String>,
+    template_type: Option<AppchainTemplateType>,
     website_url: Option<String>,
     function_spec_url: Option<String>,
     github_address: Option<String>,
@@ -46,6 +48,7 @@ pub async fn register_appchain(
             "RegisterAppchain":{
                 "appchain_id": appchain_id,
                 "description": description,
+                "template_type": template_type,
                 "website_url": website_url,
                 "function_spec_url": function_spec_url,
                 "github_address": github_address,

--- a/tests/simulator/test_case1.rs
+++ b/tests/simulator/test_case1.rs
@@ -5,7 +5,9 @@ use crate::{
         sudo_actions, voter_actions,
     },
 };
-use appchain_registry::types::{AppchainSortingField, AppchainState, SortingOrder};
+use appchain_registry::types::{
+    AppchainSortingField, AppchainState, AppchainTemplateType, SortingOrder,
+};
 use near_contract_standards::fungible_token::metadata::{FungibleTokenMetadata, FT_METADATA_SPEC};
 use near_sdk::{json_types::U128, AccountId};
 use std::{collections::HashMap, str::FromStr};
@@ -65,6 +67,7 @@ async fn test_case1() -> anyhow::Result<()> {
         &registry,
         &appchain_id,
         Some("appchain1 description".to_string()),
+        Some(AppchainTemplateType::Barnacle),
         Some("http://ddfs.dsdfs".to_string()),
         Some("https://testchain.org/function_spec".to_string()),
         Some("https://jldfs.yoasdfasd".to_string()),
@@ -120,6 +123,7 @@ async fn test_case1() -> anyhow::Result<()> {
         &registry,
         &appchain_id,
         Some("appchain1 description".to_string()),
+        Some(AppchainTemplateType::Barnacle),
         Some("http://ddfs.dsdfs".to_string()),
         Some("https://testchain.org/function_spec".to_string()),
         Some("https://jldfs.yoasdfasd".to_string()),
@@ -174,6 +178,7 @@ async fn test_case1() -> anyhow::Result<()> {
         &registry,
         &appchain_id,
         Some("appchain1 description".to_string()),
+        Some(AppchainTemplateType::Barnacle),
         Some("http://ddfs.dsdfs".to_string()),
         Some("https://testchain.org/function_spec".to_string()),
         Some("https://jldfs.yoasdfasd".to_string()),

--- a/tests/simulator/test_case2.rs
+++ b/tests/simulator/test_case2.rs
@@ -5,7 +5,9 @@ use crate::{
         registry_viewer, sudo_actions, voter_actions,
     },
 };
-use appchain_registry::types::{AppchainSortingField, AppchainState, SortingOrder};
+use appchain_registry::types::{
+    AppchainSortingField, AppchainState, AppchainTemplateType, SortingOrder,
+};
 use near_contract_standards::fungible_token::metadata::{FungibleTokenMetadata, FT_METADATA_SPEC};
 use near_sdk::{json_types::U128, AccountId};
 use std::{collections::HashMap, str::FromStr};
@@ -29,6 +31,7 @@ async fn test_case2() -> anyhow::Result<()> {
         &registry,
         &appchain_id1,
         Some("appchain1 description".to_string()),
+        Some(AppchainTemplateType::Barnacle),
         Some("http://ddfs.dsdfs".to_string()),
         Some("https://testchain.org/function_spec".to_string()),
         Some("https://jldfs.yoasdfasd".to_string()),
@@ -66,6 +69,7 @@ async fn test_case2() -> anyhow::Result<()> {
         &registry,
         &appchain_id2,
         Some("appchain2 description".to_string()),
+        Some(AppchainTemplateType::Barnacle),
         Some("http://ddfs.dsdfs".to_string()),
         Some("https://testchain.org/function_spec".to_string()),
         Some("https://jldfs.yoasdfasd".to_string()),
@@ -103,6 +107,7 @@ async fn test_case2() -> anyhow::Result<()> {
         &registry,
         &appchain_id3,
         Some("appchain3 description".to_string()),
+        Some(AppchainTemplateType::Barnacle),
         Some("http://ddfs.dsdfs".to_string()),
         Some("https://testchain.org/function_spec".to_string()),
         Some("https://jldfs.yoasdfasd".to_string()),

--- a/tests/simulator/test_case3.rs
+++ b/tests/simulator/test_case3.rs
@@ -5,7 +5,9 @@ use crate::{
         voter_actions,
     },
 };
-use appchain_registry::types::{AppchainSortingField, AppchainState, SortingOrder};
+use appchain_registry::types::{
+    AppchainSortingField, AppchainState, AppchainTemplateType, SortingOrder,
+};
 use near_contract_standards::fungible_token::metadata::{FungibleTokenMetadata, FT_METADATA_SPEC};
 use near_sdk::{json_types::U128, AccountId};
 use std::{collections::HashMap, str::FromStr};
@@ -30,6 +32,7 @@ async fn test_case3() -> anyhow::Result<()> {
             &registry,
             &appchain_id,
             Some("appchain1 description".to_string()),
+            Some(AppchainTemplateType::Barnacle),
             Some("http://ddfs.dsdfs".to_string()),
             Some("https://testchain.org/function_spec".to_string()),
             Some("https://jldfs.yoasdfasd".to_string()),

--- a/tests/simulator/test_case9.rs
+++ b/tests/simulator/test_case9.rs
@@ -1,15 +1,41 @@
-use crate::{
-    common,
-    contract_interfaces::{appchain_owner_actions, registry_viewer},
-};
-use appchain_registry::types::{
-    AppchainSortingField, RegistryRoles, RegistrySettings, SortingOrder,
+use crate::common;
+use appchain_registry::{
+    storage_migration::{OldAppchainMetadata, OldRegistrySettings},
+    types::{
+        AppchainId, AppchainSortingField, AppchainState, AppchainStatus, RegistryRoles,
+        RegistrySettings, SortingOrder,
+    },
 };
 use near_contract_standards::fungible_token::metadata::{FungibleTokenMetadata, FT_METADATA_SPEC};
-use near_sdk::{json_types::U128, serde_json, AccountId};
-use std::{collections::HashMap, str::FromStr};
+use near_sdk::{
+    json_types::{I128, U128, U64},
+    serde::{Deserialize, Serialize},
+    serde_json::{self, json},
+    AccountId,
+};
+use near_units::parse_near;
+use std::collections::HashMap;
+use workspaces::{network::Sandbox, result::ViewResultDetails, Contract, Worker};
 
 const TOTAL_SUPPLY: u128 = 100_000_000;
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(crate = "near_sdk::serde")]
+pub struct OldAppchainStatus {
+    pub appchain_id: AppchainId,
+    pub appchain_metadata: OldAppchainMetadata,
+    pub appchain_anchor: Option<AccountId>,
+    pub appchain_owner: AccountId,
+    pub register_deposit: U128,
+    pub appchain_state: AppchainState,
+    pub upvote_deposit: U128,
+    pub downvote_deposit: U128,
+    pub voting_score: I128,
+    pub registered_time: U64,
+    pub go_live_time: U64,
+    pub validator_count: u32,
+    pub total_stake: U128,
+}
 
 #[tokio::test]
 async fn test_case9() -> anyhow::Result<()> {
@@ -18,68 +44,198 @@ async fn test_case9() -> anyhow::Result<()> {
     let (root, oct_token, registry, users) =
         common::basic_actions::initialize_contracts_and_users(&worker, total_supply, true).await?;
     let amount = common::to_oct_amount(1000);
-    appchain_owner_actions::register_appchain(
+    //
+    // Register an appchain
+    //
+    let fungible_token_metadata = FungibleTokenMetadata {
+        spec: FT_METADATA_SPEC.to_string(),
+        name: "joeToken".to_string(),
+        symbol: "JOT".to_string(),
+        icon: Option::None,
+        reference: Option::None,
+        reference_hash: Option::None,
+        decimals: 18,
+    };
+    let result = common::call_ft_transfer_call(
         &worker,
-        &users[0],
-        &oct_token,
-        &registry,
-        &"appchain1".to_string(),
-        Some("appchain1 description".to_string()),
-        Some("http://ddfs.dsdfs".to_string()),
-        Some("https://testchain.org/function_spec".to_string()),
-        Some("https://jldfs.yoasdfasd".to_string()),
-        Some("v1.0.0".to_string()),
-        Some("joe@lksdf.com".to_string()),
-        Some(AccountId::from_str(users[1].id().as_str()).unwrap()),
-        Some(U128::from(10000000)),
-        Some(U128::from(10000000)),
-        Some(U128::from(1000000)),
-        Some(U128::from(100)),
-        Some(FungibleTokenMetadata {
-            spec: FT_METADATA_SPEC.to_string(),
-            name: "joeToken".to_string(),
-            symbol: "JOT".to_string(),
-            icon: Option::None,
-            reference: Option::None,
-            reference_hash: Option::None,
-            decimals: 18,
-        }),
-        Some(HashMap::from([("key1".to_string(), "value1".to_string())])),
+        &users[1],
+        &registry.as_account(),
         amount,
+        json!({
+            "RegisterAppchain":{
+                "appchain_id": "appchain1".to_string(),
+                "description": "appchain1 description".to_string(),
+                "website_url": "http://ddfs.dsdfs".to_string(),
+                "function_spec_url": "https://testchain.org/function_spec".to_string(),
+                "github_address": "https://jldfs.yoasdfasd".to_string(),
+                "github_release": "v1.0.0".to_string(),
+                "contact_email": "joe@lksdf.com".to_string(),
+                "premined_wrapped_appchain_token_beneficiary": users[1].id(),
+                "premined_wrapped_appchain_token": U128::from(10000000),
+                "initial_supply_of_wrapped_appchain_token": U128::from(10000000),
+                "ido_amount_of_wrapped_appchain_token": U128::from(100000),
+                "initial_era_reward": U128::from(100),
+                "fungible_token_metadata": fungible_token_metadata,
+                "custom_metadata": HashMap::from([("key1".to_string(), "value1".to_string())])
+            }
+        })
+        .to_string(),
+        &oct_token,
     )
-    .await
-    .expect("Failed in calling 'register_appchain'");
+    .await?;
+    println!(
+        "Result of calling 'ft_transfer_call' on OCT token account: {:?}",
+        result
+    );
+    println!();
+    assert!(result.is_success());
+    //
+    // Check view functions
+    //
+    let result = registry.call(&worker, "get_owner_pk").view().await;
+    print_view_result_details::<String>("get_owner_pk", &result);
+    //
+    let result = registry.call(&worker, "get_oct_token").view().await;
+    print_view_result_details::<AccountId>("get_oct_token", &result);
+    //
+    let result = registry.call(&worker, "get_registry_settings").view().await;
+    print_view_result_details::<OldRegistrySettings>("get_registry_settings", &result);
+    //
+    let result = registry.call(&worker, "get_registry_roles").view().await;
+    print_view_result_details::<RegistryRoles>("get_registry_roles", &result);
+    //
+    let result = registry.call(&worker, "get_total_stake").view().await;
+    print_view_result_details::<U128>("get_total_stake", &result);
+    //
+    let result = registry.call(&worker, "get_appchain_ids").view().await;
+    print_view_result_details::<Vec<String>>("get_appchain_ids", &result);
+    //
+    let result = registry
+        .call(&worker, "get_appchains_count_of")
+        .args_json(json!({ "appchain_state": null }))?
+        .view()
+        .await;
+    print_view_result_details::<U64>("get_appchains_count_of", &result);
+    //
+    let result = registry
+        .call(&worker, "get_appchains_with_state_of")
+        .args_json(json!({
+            "appchain_state": null,
+            "page_number": 1,
+            "page_size": 5,
+            "sorting_field": AppchainSortingField::RegisteredTime,
+            "sorting_order": SortingOrder::Descending,
+        }))?
+        .view()
+        .await;
+    print_view_result_details::<Vec<OldAppchainStatus>>("get_appchains_with_state_of", &result);
+    //
+    let result = registry
+        .call(&worker, "get_appchain_status_of")
+        .args_json(json!({
+            "appchain_id": "appchain1",
+        }))?
+        .view()
+        .await;
+    print_view_result_details::<OldAppchainStatus>("get_appchain_status_of", &result);
     //
     // perform migration
     //
-    common::basic_actions::deploy_new_appchain_registry(&worker, &registry).await?;
-    root.call(&worker, registry.id(), "migrate_state")
+    root.call(&worker, registry.id(), "store_wasm_of_self")
+        .args(std::fs::read(format!("res/appchain_registry.wasm"))?)
+        .gas(300_000_000_000_000)
+        .deposit(parse_near!("6 N"))
+        .transact()
+        .await
+        .expect("Failed in calling 'store_wasm_of_self'");
+    root.call(&worker, registry.id(), "set_owner")
+        .args_json(json!({
+            "owner": registry.id(),
+        }))?
+        .gas(200_000_000_000_000)
+        .transact()
+        .await
+        .expect("Failed in calling 'set_owner'");
+    let result = registry
+        .call(&worker, "update_self")
         .gas(300_000_000_000_000)
         .transact()
         .await?;
+    println!("Result of calling 'update_self': {:?}", result);
+    println!();
+    assert!(result.is_success());
     //
-    let registry_settings = registry_viewer::get_registry_settings(&worker, &registry).await?;
-    println!(
-        "Registry settings: {}",
-        serde_json::to_string::<RegistrySettings>(&registry_settings).unwrap()
-    );
-    let registry_roles = registry_viewer::get_registry_roles(&worker, &registry).await?;
-    println!(
-        "Registry roles: {}",
-        serde_json::to_string::<RegistryRoles>(&registry_roles).unwrap()
-    );
-    assert_eq!(
-        registry_viewer::print_appchains(
-            &worker,
-            &registry,
-            Option::None,
-            1,
-            5,
-            AppchainSortingField::RegisteredTime,
-            SortingOrder::Descending
-        )
-        .await?,
-        1
-    );
+    print_view_function_results(&worker, &registry).await;
+    //
     Ok(())
+}
+
+async fn print_view_function_results(worker: &Worker<Sandbox>, registry: &Contract) {
+    //
+    let result = registry.call(&worker, "get_owner_pk").view().await;
+    print_view_result_details::<String>("get_owner_pk", &result);
+    //
+    let result = registry.call(&worker, "get_oct_token").view().await;
+    print_view_result_details::<AccountId>("get_oct_token", &result);
+    //
+    let result = registry.call(&worker, "get_registry_settings").view().await;
+    print_view_result_details::<RegistrySettings>("get_registry_settings", &result);
+    //
+    let result = registry.call(&worker, "get_registry_roles").view().await;
+    print_view_result_details::<RegistryRoles>("get_registry_roles", &result);
+    //
+    let result = registry.call(&worker, "get_total_stake").view().await;
+    print_view_result_details::<U128>("get_total_stake", &result);
+    //
+    let result = registry.call(&worker, "get_appchain_ids").view().await;
+    print_view_result_details::<Vec<String>>("get_appchain_ids", &result);
+    //
+    let result = registry
+        .call(&worker, "get_appchains_count_of")
+        .args_json(json!({ "appchain_state": null }))
+        .unwrap()
+        .view()
+        .await;
+    print_view_result_details::<U64>("get_appchains_count_of", &result);
+    //
+    let result = registry
+        .call(&worker, "get_appchains_with_state_of")
+        .args_json(json!({
+            "appchain_state": null,
+            "page_number": 1,
+            "page_size": 5,
+            "sorting_field": AppchainSortingField::RegisteredTime,
+            "sorting_order": SortingOrder::Descending,
+        }))
+        .unwrap()
+        .view()
+        .await;
+    print_view_result_details::<Vec<AppchainStatus>>("get_appchains_with_state_of", &result);
+    //
+    let result = registry
+        .call(&worker, "get_appchain_status_of")
+        .args_json(json!({
+            "appchain_id": "appchain1",
+        }))
+        .unwrap()
+        .view()
+        .await;
+    print_view_result_details::<AppchainStatus>("get_appchain_status_of", &result);
+}
+
+fn print_view_result_details<
+    T: near_sdk::serde::Serialize + for<'de> near_sdk::serde::Deserialize<'de>,
+>(
+    function_name: &str,
+    result: &Result<ViewResultDetails, anyhow::Error>,
+) {
+    match result {
+        Ok(result) => println!(
+            "{}: {}",
+            function_name,
+            serde_json::to_string(&result.json::<T>().unwrap()).unwrap()
+        ),
+        Err(error) => println!("{}: {:?}", function_name, error),
+    }
+    println!();
 }


### PR DESCRIPTION
## All Changes

* Add field `evm_chain_id` to `AppchainBaseData` and `AppchainStatus`. Its type is `Option<U64>`.
* Add field `template_type` to `AppchainMetadata` and `RegistryDepositMessage::RegisterAppchain`. Its type is `AppchainTemplateType`, which is defined as:

```rust
pub enum AppchainTemplateType {
    Barnacle,
    BarnacleEvm,
}
```

* Add necessary contract functions for the above new fields.
* Add length checking for `appchain id`. Now the length can not exceed 20.
